### PR TITLE
Implement some convience traits for primative types.

### DIFF
--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -668,3 +668,13 @@ impl Fps {
         }
     }
 }
+impl From<Fps> for f32 {
+    fn from(x: Fps) -> Self {
+        x.as_f32()
+    }
+}
+impl From<Fps> for u8 {
+    fn from(x: Fps) -> Self {
+        x.as_int()
+    }
+}

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -269,6 +269,28 @@ macro_rules! restricted_int {
                 Some(self.cmp(&rhs.as_int()))
             }
         }
+        impl std::ops::Add for $name {
+            type Output = Self;
+            fn add(self, other: Self) -> Self {
+                Self::new(self.as_int() + other.as_int())
+            }
+        }
+        impl std::ops::Sub for $name {
+            type Output = Self;
+            fn sub(self, other: Self) -> Self {
+                Self::new(self.as_int() - other.as_int())
+            }
+        }
+        impl std::ops::AddAssign for $name {
+            fn add_assign(&mut self, other: Self) {
+                *self = *self + other
+            }
+        }
+        impl std::ops::SubAssign for $name {
+            fn sub_assign(&mut self, other: Self) {
+                *self = *self - other
+            }
+        }
 
         $( int_feature!{$name ; $inner : $feature} )*
     };


### PR DESCRIPTION
This PR implements `Add`, `Sub`, `AddAssign`, and `SubAssign` for the basic integer primatives (`u4`, `u7`, `u14`, `u24`, and `u28`). I find this to be useful when working with things such as ticks, which are usually encoded as `u28`s.

This PR also implements `From<Fps>` for `u32` and `f32`. This is simply for convenience, since there are already `as_f32` and `as_int` methods on `Fps`.