### PR TITLE
WIP: Better support for primitive ops

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -620,3 +620,29 @@ impl<'a> MetaMessage<'a> {
         }
     }
 }
+
+impl<'a> core::fmt::Display for MetaMessage<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut print_ascii = |bytes: &[u8], name: &str | {
+            if let Ok(s) = core::str::from_utf8(bytes){
+                write!(f, "{name}(\"{s}\")")
+            }
+            else {
+                write!(f, "{:?}", self)
+            }
+        };
+
+        match self {
+            MetaMessage::Text(bytes) => print_ascii(bytes, "Text"),
+            MetaMessage::Copyright(bytes) => print_ascii(bytes, "Copyright"),
+            MetaMessage::TrackName(bytes) => print_ascii(bytes, "TrackName"),
+            MetaMessage::InstrumentName(bytes) => print_ascii(bytes, "InstrumentName"),
+            MetaMessage::Lyric(bytes) => print_ascii(bytes, "Lyric"),
+            MetaMessage::Marker(bytes) => print_ascii(bytes, "Marker"),
+            MetaMessage::CuePoint(bytes) => print_ascii(bytes, "CuePoint"),
+            MetaMessage::ProgramName(bytes) => print_ascii(bytes, "ProgramName"),
+            MetaMessage::DeviceName(bytes) => print_ascii(bytes, "DeviceName"),
+            _ => write!(f, "{:?}", self),
+        }
+    }
+}

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -328,6 +328,14 @@ macro_rules! restricted_int {
         $( int_feature!{$name ; $inner : $feature} )*
     };
 }
+
+impl core::ops::Add<i8> for u7 {
+    type Output = Self;
+    fn add(self, other: i8) -> Self {
+        Self::new((u8::from(self) as usize).wrapping_add_signed(other.into()) as u8)
+    }
+}
+
 restricted_int! {
     /// A 15-bit integer type.
     ///


### PR DESCRIPTION
See #26 for use case

So this is just the use case I need at the moment and I'm not sure about how it would fit in the library that's why I'm submitting this WIP to know if it's even useful to develop something broader.

It can be easily expanded with 
```rust
impl<T: core::convert::Into<isize>> core::ops::Add<T> for $name {
    type Output = Self;
    fn add(self, other: T) -> Self {
        Self::new(($inner::from(self) as usize).wrapping_add_signed(other.into()) as $inner)
    }
}
```
In the restricted_int macro but I need to further investigate this one that's why I didn't commit it.

I have started thinking a bit more about it and it has some implications that's why I wanted to ask you about your views on this, I'm not really used to contributing but I wanna start so apologies if this is inconvenient.

My view is for the specific case of adding signed number to key or velocity it's useful.

I also thought about implementing some ops between u28 and u15 because : Timing::Metrical(u15) and delta: u28. Modulo to do something every n beats is an example use case for this one.

Thank you for your time