### PR TITLE
added serde feature for MidiMessage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.5.3"
 edition = "2018"
 authors = ["negamartin"]
 include = [
-  "/src/*",
-  "/Cargo.toml",
+    "/src/*",
+    "/Cargo.toml",
 ]
 description = "Fast MIDI decoder and encoder both for .mid files and real-time MIDI events"
 repository = "https://github.com/negamartin/midly"
@@ -39,6 +39,8 @@ std = ["alloc"]
 # Multithreaded parsing is automatically disabled for tiny MIDI files.
 # Currently, multithreading brings in the `rayon` dependency.
 parallel = ["std", "rayon"]
+serde = ["dep:serde"]
 
 [dependencies]
-rayon = { version="1", optional = true }
+rayon = { version = "1", optional = true }
+serde = { version = "1.0.198", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ serde = ["dep:serde"]
 
 [dependencies]
 rayon = { version = "1", optional = true }
-serde = { version = "1.0.198", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, features = ["derive"] }

--- a/src/event.rs
+++ b/src/event.rs
@@ -231,6 +231,7 @@ impl<'a> TrackEventKind<'a> {
 /// [`LiveEvent::parse`](live/enum.LiveEvent.html#method.parse) method instead and ignore all
 /// variants except for [`LiveEvent::Midi`](live/enum.LiveEvent.html#variant.Midi).
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum MidiMessage {
     /// Stop playing a note.
     NoteOff {
@@ -387,6 +388,7 @@ impl MidiMessage {
 /// A value of `0x2000` indicates no bend.
 /// A value of `0x3FFF` indicates full bend upwards.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PitchBend(pub u14);
 impl PitchBend {
     /// The minimum value of `0x0000`, indicating full bend downwards.

--- a/src/live.rs
+++ b/src/live.rs
@@ -23,6 +23,7 @@ use crate::{event::TrackEventKind, Arena};
 ///
 /// See the [`live`](index.html) module for more information.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum LiveEvent<'a> {
     /// A MIDI message associated with a channel, carrying musical data.
     ///
@@ -210,11 +211,13 @@ impl<'a> LiveEvent<'a> {
 
 /// A "system common event", as defined by the MIDI spec.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SystemCommon<'a> {
     /// A system-exclusive event.
     ///
     /// System Exclusive events start with a `0xF0` byte and finish with a `0xF7` byte, but this
     /// slice does not include either: it only includes data bytes in the `0x00..=0x7F` range.
+    #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     SysEx(&'a [u7]),
     /// A MIDI Time Code Quarter Frame message, carrying a tag type and a 4-bit tag value.
     MidiTimeCodeQuarterFrame(MtcQuarterFrameMessage, u4),
@@ -226,6 +229,7 @@ pub enum SystemCommon<'a> {
     /// Request the device to tune itself.
     TuneRequest,
     /// An undefined System Common message, with arbitrary data bytes.
+    #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     Undefined(u8, &'a [u7]),
 }
 impl<'a> SystemCommon<'a> {
@@ -311,6 +315,7 @@ impl<'a> SystemCommon<'a> {
 
 /// The different kinds of info a Midi Time Code Quarter Frame message can carry.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum MtcQuarterFrameMessage {
     /// The low nibble of the frame count.
     FramesLow,
@@ -363,6 +368,7 @@ impl MtcQuarterFrameMessage {
 /// They are usually time-sensitive, get top priority and can even be transmitted in between other
 /// messages.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SystemRealtime {
     /// If sent, they should be sent 24 times per quarter note.
     TimingClock,
@@ -379,6 +385,7 @@ pub enum SystemRealtime {
     /// Usually, turns off all playing notes, clears running status, sets song position to 0, etc...
     Reset,
     /// An unknown system realtime message, with the given id byte.
+    #[cfg_attr(feature = "serde", serde(untagged))]
     Undefined(u8),
 }
 impl SystemRealtime {

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -96,6 +96,7 @@ macro_rules! restricted_int {
     {$(#[$attr:meta])* $name:ident : $inner:tt => $bits:expr ; $( $feature:tt )* } => {
         $(#[$attr])*
         #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Default)]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         #[repr(transparent)]
         #[allow(non_camel_case_types)]
         pub struct $name($inner);


### PR DESCRIPTION
For a project I am working on serde support for the `MidiMessage` is useful. 

I have implemented `deserialize` and `serialize` for just that enum and its contents but if you were interested in this PR I could expand to impl more types. 